### PR TITLE
Fix bug when retrieving field values

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1537,12 +1537,7 @@ class Schema {
               'type' => $fieldType,
               'description' => isset($field_info['description']) ? $field_info['description'] : '',
               'resolve' => function ($value, $args, $context, ResolveInfo $info) use ($entity_type, $bundle, $field) {
-                $wrap = entity_metadata_wrapper($entity_type, $value);
-                if ($wrap->__isset($field)) {
-                  $items = $wrap->{$field}->value();
-                  return $items;
-                }
-                return NULL;
+                return field_get_items($entity_type, $value, $field)[0];
               }
             ];
           }


### PR DESCRIPTION
This seems to fix #22 

Field Collections and Text now seem to work...

For this query:
```
query {
  node(nid:"6") {
    nid
    title
    field_teaser_text {
      value
      format
    }
  }
}
```

Before:
```
  "data": {
    "node": [
      {
        "nid": "6",
        "title": "EXAMPLE",
        "field_teaser_text": {
          "value": null,
          "format": null
        }
      }
    ]
  }
```

Now:
```
  "data": {
    "node": [
      {
        "nid": "6",
        "title": "EXAMPLE",
        "field_teaser_text": {
          "value": "Some teaser text value",
          "format": "filtered_html"
        }
      }
    ]
  }
```