### PR TITLE
Taxonomy term vocabulary not working

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1444,9 +1444,6 @@ class Schema {
             if (($value instanceof \EntityDrupalWrapper)) {
               $wrap = $value;
             } else {
-              if ($value && !($value instanceof \Entity) && $entity_type != 'user') {
-                return isset($value->{$property}) ? $value->{$property} : null;
-              }
               if (method_exists($value, 'wrapper')) {
                 $wrap = $value->wrapper();
               } else {


### PR DESCRIPTION
I think the problem lies around here:
https://github.com/olragon/graphql_api/blob/134df5810a244b8f50dc3ca0a9d7968faf8215be/src/Schema.php#L1448

If I do this:
```
query {
  taxonomy_term(tid:"27074" ) {
    tid
    name
    vocabulary {
      vid
      name
    }
  }
}
```

I get:
```
  "data": {
    "taxonomy_term": [
      {
        "tid": "27074",
        "name": "",
        "vocabulary": null
      }
    ]
  },
```

I think this is because vocabulary is being treated as a property on a term?